### PR TITLE
multiprocessing이 가능하도록 dataextractor변경

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,3 +1,5 @@
+import time
+from multiprocessing import Pool
 from unittest import TestCase, main
 
 import numpy as np
@@ -117,6 +119,23 @@ class DataLoaderSimpleTest(TestCase):
             [24, -1]],
             columns=['bcateid', 'price'], dtype='int32')
         assert_frame_equal(pred, answer)
+
+    def test_get_value_by_multiprocessing(self):
+        pool = Pool(100)
+        rc = pool.map_async(get_add_value, range(0, 1000))
+        result = rc.get()
+        self.assertEqual(sum(result), 0)
+
+
+def get_add_value(i):
+    dex = DataExtractor("test.h5", 'train')
+    for j in range(0, 10):
+        time.sleep(0.0001)
+        try:
+            x = dex['model', j]
+        except:
+            return True
+    return False
 
 
 class DataLoaderNumpyOutTest(TestCase):


### PR DESCRIPTION
현재 코드는 h5 파일에 대한 Lock을 잡고 있어서, multiprocessing할 경우 문제가 발생한다. 그것을 방지하기 위해 

1. h5 파일에 접근할 때만 lock을 잡도록 함
2. h5 파일 접근은 read 권한으로만 

으로 작업하였습니다.